### PR TITLE
Fix tabs_to_bottom.userchrome.css for firefox version 119

### DIFF
--- a/tabs_to_bottom.userchrome.css
+++ b/tabs_to_bottom.userchrome.css
@@ -18,13 +18,12 @@ Tabs to Bottom
 source: https://github.com/Arty2/userstyles/blob/master/tabs_to_bottom.userchrome.css
 
 UI model:
-	#navigator-toolbox-background
-		#navigator-toolbox
-			#titlebar
-				#toolbar-menubar
-				#TabsToolbar
-			#nav-bar
-			#PersonalToolbar
+	#navigator-toolbox
+		#titlebar
+			#toolbar-menubar
+			#TabsToolbar
+		#nav-bar
+		#PersonalToolbar
 	#browser
 */
 
@@ -34,7 +33,7 @@ UI model:
 	order: 0 !important;
 }
 
-#navigator-toolbox-background {
+#navigator-toolbox {
 	-moz-box-ordinal-group: 1 !important;
 	order: 1 !important;
 }


### PR DESCRIPTION
Firefox version 119 removed the navigator-toolbox-background class meaning that the navigator toolbox was not being moved to the bottom of the window anymore. Renaming it to navigator-toolbox fixes this.