### PR TITLE
tabs_to_bottom: hide the nav bar and tabs when in fullscreen

### DIFF
--- a/tabs_to_bottom.userchrome.css
+++ b/tabs_to_bottom.userchrome.css
@@ -45,9 +45,8 @@ UI model:
 }
 
 /* hide tab toolbar when fullscreen */
-#nav-bar[inFullscreen],
-#TabsToolbar[inFullscreen] {
-	display: none;
+*|*:root[inFullscreen] #navigator-toolbox {
+        display: none;
 }
 
 /* restore top border */


### PR DESCRIPTION
A couple of months ago a firefox update broke the code hiding the tab toolbar in fullscreen. This restores that functionality.

fixes issue #7