### PR TITLE
Tabs to bottom - search engine icon fix

### DIFF
--- a/tabs_to_bottom.userchrome.css
+++ b/tabs_to_bottom.userchrome.css
@@ -46,7 +46,7 @@ UI model:
 
 /* hide tab toolbar when fullscreen */
 *|*:root[inFullscreen] #navigator-toolbox {
-        display: none;
+    display: none;
 }
 
 /* restore top border */
@@ -59,8 +59,8 @@ UI model:
 
 /* make toolbar border persist on fullscreen */
 *|*:root[sizemode="maximized"] #navigator-toolbox {
-  border-top: .5px solid AccentColor !important;
-  border-bottom: .5px solid AccentColor !important;
+	border-top: .5px solid AccentColor !important;
+	border-bottom: .5px solid AccentColor !important;
 }
 
 /* hide titlebar buttons */
@@ -70,10 +70,16 @@ UI model:
 
 /*fix pop-ups opening below window*/
 #urlbar[open]{
-  display: flex !important;
-  flex-direction: column-reverse; /* use 'column' if you want to type the URL in center*/
-  bottom: -2px !important;
-  top: auto !important;
+	display: flex !important;
+	flex-direction: column-reverse; /* use 'column' if you want to type the URL in center*/
+	bottom: -2px !important;
+	top: auto !important;
 }
 /*.urlbarView-body-inner { border-top: none !important; }*/
 /*.urlbarView { display: none !important; }*/ /* uncomment this to hidden address bar suggestions */
+
+/* removes wierd 1px borders above/below the navigator toolbox */
+:root[sizemode="maximized"] #navigator-toolbox {
+	border-top: 0px !important;
+	border-bottom: 0px !important;
+}

--- a/tabs_to_bottom.userchrome.css
+++ b/tabs_to_bottom.userchrome.css
@@ -79,7 +79,14 @@ UI model:
 /*.urlbarView { display: none !important; }*/ /* uncomment this to hidden address bar suggestions */
 
 /* removes wierd 1px borders above/below the navigator toolbox */
+#navigator-toolbox {
+        border-bottom: 0px !important;
+}
+:root[sizemode="normal"] #browser {
+        border-top: 0px !important;
+}
 :root[sizemode="maximized"] #navigator-toolbox {
 	border-top: 0px !important;
 	border-bottom: 0px !important;
 }
+

--- a/tabs_to_bottom.userchrome.css
+++ b/tabs_to_bottom.userchrome.css
@@ -90,3 +90,13 @@ UI model:
 	border-bottom: 0px !important;
 }
 
+/* stops the new search engine drop-down icon from floating in the middle of the screen */
+@media -moz-pref("browser.urlbar.searchModeSwitcher.featureGate") or -moz-pref("browser.urlbar.scotchBonnet.enableOverride") {
+  @media not -moz-pref("browser.urlbar.unifiedSearchButton.always") {
+    #urlbar-searchmode-switcher {
+      #urlbar:not([unifiedsearchbutton-available]) > .urlbar-input-container > & {
+        position: unset !important;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Stops the new search engine drop-down icon from floating in the middle of the screen